### PR TITLE
Fix merge layer IO parsing

### DIFF
--- a/src/keras2c/layer2c.py
+++ b/src/keras2c/layer2c.py
@@ -48,7 +48,15 @@ class Layers2C():
         while len(unwritten_io) > 0:
             for layer in self.model.layers:
                 layer_inputs, layer_outputs = get_layer_io_names(layer)
-                for i, (inp, outp) in enumerate(zip(layer_inputs, layer_outputs)):
+                if len(layer_outputs) == 0:
+                    continue
+                if len(layer_inputs) > 1:
+                    inp = layer_inputs
+                elif len(layer_inputs) == 1:
+                    inp = layer_inputs[0]
+                else:
+                    inp = []
+                for i, outp in enumerate(layer_outputs):
                     if (
                         set(flatten(inp)).issubset(written_io)
                         and set(flatten(outp)).issubset(unwritten_io)


### PR DESCRIPTION
## Summary
- fix logic for writing layers so that multi-input operations get all inputs
- fix generation of weight counts for merge and concatenate layers
- ensure output tensors use correct variable names

## Testing
- `pytest tests/test_merge_layers.py::TestMergeLayers::test_Subtract1 -q`
- `pytest tests/test_merge_layers.py::TestMergeLayers::test_Add1 -q`
- `pytest tests/test_merge_layers.py::TestMergeLayers::test_Concatenate1 -q`
- `pytest tests/test_core_layers.py::TestCoreLayers::test_Dense3_Activation -q`
- `pytest tests/test_core_layers.py::TestCoreLayers::test_dummy_layers -q`
- `pytest tests/test_models.py::TestModels::test_ProfilePredictor -q`
- `pytest tests/test_merge_layers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684105d235508324818b56829b256cdd