### PR TITLE
Fix typo in scratch notebook

### DIFF
--- a/scratch/scratch.ipynb
+++ b/scratch/scratch.ipynb
@@ -38,7 +38,7 @@
     "         merge with different sizes\n",
     "         conv3d\n",
     "         pool3d\n",
-    "         seperable conv\n",
+    "         separable conv\n",
     "         conv transpose\n",
     "         depthwise conv\n",
     "         crop3d\n",


### PR DESCRIPTION
## Summary
- correct the misspelling of "separable" in `scratch/scratch.ipynb`

## Testing
- `pytest -q` *(fails: compilation failed)*

------
https://chatgpt.com/codex/tasks/task_e_6841070ef09c8324a1ac296b70357269