### PR TITLE
Fix ThresholdedReLU weight accumulation

### DIFF
--- a/src/keras2c/weights2c.py
+++ b/src/keras2c/weights2c.py
@@ -664,7 +664,7 @@ class Weights2C:
 
     def _write_weights_ThresholdedReLU(self, layer):
         theta = layer.get_config()['theta']
-        self.stack_vars = 'float ' + layer.name + \
+        self.stack_vars += 'float ' + layer.name + \
             '_theta = ' + str(theta) + '; \n'
         self.stack_vars += '\n\n'
 


### PR DESCRIPTION
## Summary
- ensure ThresholdedReLU weights append to `stack_vars`

## Testing
- `pytest -q` *(fails: compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_684107103b84832484d0355119765019