### PR TITLE
Refactor imports for TensorFlow 2

### DIFF
--- a/src/keras2c/backend.py
+++ b/src/keras2c/backend.py
@@ -1,0 +1,12 @@
+"""Backend utilities for :mod:`keras2c`.
+
+This module exposes the Keras API used throughout the project. By keeping the
+backend import in a single place it becomes easier to switch to a different
+deep learning framework in the future.  Currently TensorFlow's Keras
+implementation is used which requires TensorFlow 2.x.
+"""
+
+from tensorflow import keras
+
+__all__ = ["keras"]
+

--- a/src/keras2c/io_parsing.py
+++ b/src/keras2c/io_parsing.py
@@ -6,7 +6,7 @@ https://github.com/f0uriest/keras2c
 
 Helper functions to get input and output names for each layer etc.
 """
-import keras
+from .backend import keras
 
 __author__ = "Rory Conlin"
 __copyright__ = "Copyright 2020, Rory Conlin"
@@ -94,11 +94,7 @@ def get_layer_num_io(layer):
             else:
                 num_outputs = 1
 
-        # Determine if it's a multi-input layer
-        if num_inputs > 1:
-            print("This is a multi-input layer.")
-        else:
-            print("This is a single-input layer.")
+
 
     return num_inputs, num_outputs
 
@@ -121,7 +117,6 @@ def get_layer_io_names(layer):
         # InputLayer has no inputs, only an output
         name = layer.output.name.split(':')[0].split('/')[0]
         outputs.append(name)
-        print("This is an InputLayer.")
     else:
         # Handle layers with multiple inputs
         if hasattr(layer, 'input'):
@@ -143,7 +138,7 @@ def get_layer_io_names(layer):
                 name = input_tensors.name.split(':')[0].split('/')[0]
                 inputs.append(name)
         else:
-            print(f"No inputs found for layer {layer.name}")
+            pass
 
         # Handle layers with multiple outputs
         if hasattr(layer, 'output'):
@@ -165,13 +160,9 @@ def get_layer_io_names(layer):
                 name = output_tensors.name.split(':')[0].split('/')[0]
                 outputs.append(name)
         else:
-            print(f"No outputs found for layer {layer.name}")
+            pass
 
-        # Determine if it's a multi-input layer
-        if len(inputs) > 1:
-            print("This is a multi-input layer.")
-        else:
-            print("This is a single-input layer.")
+
 
     return inputs, outputs
 

--- a/src/keras2c/keras2c_main.py
+++ b/src/keras2c/keras2c_main.py
@@ -17,7 +17,7 @@ from keras2c.check_model import check_model
 from keras2c.make_test_suite import make_test_suite
 import numpy as np
 import subprocess
-from tensorflow import keras
+from .backend import keras
 
 
 __author__ = "Rory Conlin"

--- a/src/keras2c/layer2c.py
+++ b/src/keras2c/layer2c.py
@@ -11,7 +11,7 @@ Writes individual layers to C code
 from keras2c.io_parsing import (
     layer_type, get_model_io_names, get_all_io_names, get_layer_io_names, flatten
 )
-import keras
+from .backend import keras
 
 __author__ = "Rory Conlin"
 __copyright__ = "Copyright 2020, Rory Conlin"

--- a/src/keras2c/make_test_suite.py
+++ b/src/keras2c/make_test_suite.py
@@ -12,7 +12,7 @@ import numpy as np
 from keras2c.io_parsing import get_model_io_names
 from keras2c.weights2c import Weights2C
 import subprocess
-from tensorflow import keras
+from .backend import keras
 
 __author__ = "Rory Conlin"
 __copyright__ = "Copyright 2020, Rory Conlin"

--- a/src/keras2c/weights2c.py
+++ b/src/keras2c/weights2c.py
@@ -10,7 +10,7 @@ Gets weights and other parameters from each layer and writes to C file
 # Imports
 import numpy as np
 from keras2c.io_parsing import layer_type, get_layer_io_names, get_model_io_names
-from tensorflow import keras
+from .backend import keras
 
 maxndim = 5
 

--- a/tests/test_convolution_layers.py
+++ b/tests/test_convolution_layers.py
@@ -6,7 +6,7 @@ Implements tests for convolution layers
 #!/usr/bin/env python3
 
 import unittest
-import keras
+from tensorflow import keras
 from keras2c import keras2c_main
 import time
 from test_core_layers import build_and_run

--- a/tests/test_malloc.py
+++ b/tests/test_malloc.py
@@ -6,7 +6,7 @@ Implements tests for dynamic memory allocation
 #!/usr/bin/env python3
 
 import unittest
-import keras
+from tensorflow import keras
 from keras2c import keras2c_main
 import time
 from test_core_layers import build_and_run

--- a/tests/test_merge_layers.py
+++ b/tests/test_merge_layers.py
@@ -6,7 +6,7 @@ Implements tests for merge layers
 #!/usr/bin/env python3
 
 import unittest
-import keras
+from tensorflow import keras
 from keras2c import keras2c_main
 import time
 from test_core_layers import build_and_run

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,14 +6,14 @@ Implements tests for full models
 #!/usr/bin/env python3
 
 import unittest
-import keras
-from keras import layers
-from keras.layers import (
+from tensorflow import keras
+from tensorflow.keras import layers
+from tensorflow.keras.layers import (
     Input, Dense, LSTM, Conv1D, Conv2D, ConvLSTM2D, Dot, Add,
     Multiply, Concatenate, Reshape, Permute, ZeroPadding1D, Cropping1D,
     Activation, MaxPooling2D, Dropout, Flatten
 )
-from keras.models import Model, Sequential
+from tensorflow.keras.models import Model, Sequential
 from keras2c import keras2c_main
 import time
 from test_core_layers import build_and_run

--- a/tests/test_pooling_layers.py
+++ b/tests/test_pooling_layers.py
@@ -6,14 +6,14 @@ Implements tests for pooling layers
 #!/usr/bin/env python3
 
 import unittest
-import keras
-from keras import layers
-from keras.layers import (
+from tensorflow import keras
+from tensorflow.keras import layers
+from tensorflow.keras.layers import (
     Input, MaxPooling1D, AveragePooling1D, MaxPooling2D, AveragePooling2D,
     GlobalAveragePooling1D, GlobalMaxPooling1D, GlobalAveragePooling2D,
     GlobalMaxPooling2D, GlobalAveragePooling3D, GlobalMaxPooling3D
 )
-from keras.models import Model
+from tensorflow.keras.models import Model
 from keras2c import keras2c_main
 import time
 from test_core_layers import build_and_run

--- a/tests/test_recurrent_layers.py
+++ b/tests/test_recurrent_layers.py
@@ -6,9 +6,9 @@ Implements tests for recurrent layers
 #!/usr/bin/env python3
 
 import unittest
-import keras
-from keras.layers import Input, SimpleRNN, LSTM, GRU
-from keras.models import Model
+from tensorflow import keras
+from tensorflow.keras.layers import Input, SimpleRNN, LSTM, GRU
+from tensorflow.keras.models import Model
 from keras2c import keras2c_main
 import time
 from test_core_layers import build_and_run

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -7,8 +7,8 @@ Implements tests for layer wrappers
 
 import unittest
 import time
-from keras.models import Sequential, Model
-from keras.layers import (
+from tensorflow.keras.models import Sequential, Model
+from tensorflow.keras.layers import (
     Input, Dense, LSTM, Bidirectional, TimeDistributed, Conv1D, Conv2D
 )
 from keras2c import keras2c_main


### PR DESCRIPTION
## Summary
- centralize Keras backend in new `backend.py`
- adjust library modules to import Keras from new backend
- clean debug prints
- switch tests to use `tensorflow.keras`

## Testing
- `pip install tensorflow==2.16.2 numpy pytest pytest-cov --quiet`
- `pytest -q` *(fails: compilation errors in C build)*

------
https://chatgpt.com/codex/tasks/task_e_684106f400608324b9c22a0238ab3212