### PR TITLE
Fix data generation and malloc initialization

### DIFF
--- a/src/keras2c/keras2c_main.py
+++ b/src/keras2c/keras2c_main.py
@@ -147,10 +147,15 @@ def gen_function_initialize(function_name, malloc_vars):
     init_fun = init_sig
     init_fun += ' { \n\n'
     for key, value in malloc_vars.items():
-        init_fun += '*' + key + " = (float*) malloc(" + str(value.size) + " * sizeof(float)); \n"
-        init_fun += "for (size_t i = 0; i < " + str(value.size) + "; ++i) {\n"
-        init_fun += "    (*" + key + ")[i] = " + str(value.flatten(order='C')[0]) + "f;\n"
-        init_fun += "}\n"
+        flat = value.flatten(order='C')
+        init_fun += 'static const float ' + key + '_init[' + str(flat.size) + '] = {\n'
+        for idx, val in enumerate(flat):
+            init_fun += f'{val:+.8e}f,'
+            if (idx + 1) % 5 == 0:
+                init_fun += '\n'
+        init_fun += '};\n'
+        init_fun += '*' + key + ' = (float*) malloc(' + str(flat.size) + ' * sizeof(float)); \n'
+        init_fun += 'memcpy(*' + key + ', ' + key + '_init, ' + str(flat.size) + ' * sizeof(float));\n'
     init_fun += "} \n\n"
 
     return init_sig, init_fun

--- a/src/keras2c/make_test_suite.py
+++ b/src/keras2c/make_test_suite.py
@@ -90,7 +90,19 @@ def make_test_suite(
         while True:
             rand_inputs = []
             for j in range(num_inputs):
-                rand_input = 4 * np.random.random(size=tuple(input_shape[j])) - 2
+                inp_layer = model.inputs[j]
+                if hasattr(inp_layer, 'dtype') and np.issubdtype(np.dtype(inp_layer.dtype), np.integer):
+                    high = 10
+                    # attempt to infer size from connected Embedding layer
+                    for layer in model.layers:
+                        for node in layer._inbound_nodes:
+                            if inp_layer in getattr(node, 'input_tensors', []):
+                                if hasattr(layer, 'input_dim'):
+                                    high = layer.input_dim
+                                break
+                    rand_input = np.random.randint(0, high, size=tuple(input_shape[j]), dtype=np.dtype(inp_layer.dtype))
+                else:
+                    rand_input = 4 * np.random.random(size=tuple(input_shape[j])) - 2
                 if not stateful:
                     rand_input = rand_input[np.newaxis, ...]
                 rand_inputs.append(rand_input)

--- a/src/keras2c/weights2c.py
+++ b/src/keras2c/weights2c.py
@@ -227,10 +227,16 @@ class Weights2C:
     def _write_weights_BatchNormalization(self, layer):
         center = layer.get_config()['center']
         scale = layer.get_config()['scale']
-        if isinstance(layer.get_config()['axis'], (list, tuple, np.ndarray)):
-            axis = layer.get_config()['axis'][0]-1
+        axis_cfg = layer.get_config()['axis']
+        if isinstance(axis_cfg, (list, tuple, np.ndarray)):
+            axis_cfg = axis_cfg[0]
+        if isinstance(layer.input, (list, tuple)):
+            ndim = len(layer.input[0].shape)
         else:
-            axis = layer.get_config()['axis']-1
+            ndim = len(layer.input.shape)
+        if axis_cfg < 0:
+            axis_cfg = ndim + axis_cfg
+        axis = axis_cfg - 1
 
         epsilon = layer.get_config()['epsilon']
 


### PR DESCRIPTION
## Summary
- handle integer input data correctly when generating tests
- compute batch norm axis correctly
- initialize dynamic memory variables with full weight values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841098cdf3c8324b8f1be17b67e7b07