### PR TITLE
Improve linting setup

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,6 +18,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Analysing the code with pylint
       run: |
         pylint $(git ls-files '*.py')

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-pylint
+    rev: v2.15.0
+    hooks:
+      - id: pylint
+        additional_dependencies: [tensorflow, numpy]

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,4 @@
+[MASTER]
+
+[FORMAT]
+max-line-length=120

--- a/src/keras2c/__main__.py
+++ b/src/keras2c/__main__.py
@@ -48,6 +48,7 @@ def parse_args(args):
 
 
 def main(args=None):
+    """Entry point for the ``keras2c`` command line interface."""
     if args is None:
         args = sys.argv[1:]
 

--- a/src/keras2c/weights2c.py
+++ b/src/keras2c/weights2c.py
@@ -382,16 +382,16 @@ class Weights2C:
             b = weights[1]
         else:
             b = np.zeros(A.shape[1])  # No bias term
-    
+
         self._write_weights_array2c(A, f"{layer.name}_kernel")
         self._write_weights_array2c(b, f"{layer.name}_bias")
 
         input_shape = layer.input.shape
         output_shape = layer.output.shape
-        
+
         # Exclude the batch dimension and handle None values
         input_shape = [dim if dim is not None else 1 for dim in input_shape[1:]]
-    
+
         fwork_size = np.prod(input_shape) + np.prod(output_shape[1:])
         self.stack_vars += f'float {layer.name}_fwork[{fwork_size}] = {{0}}; \n'
         self.stack_vars += '\n \n'

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -21,12 +21,14 @@ class TestChecks(unittest.TestCase):
     """tests for model validity checking"""
 
     def test_is_model(self):
+        """Non-Model input should raise ``ValueError``."""
         model = np.arange(10)
         name = 'foo'
         with self.assertRaises(ValueError):
             keras2c_main.k2c(model, name)
 
     def test_is_valid_cname(self):
+        """Invalid C identifier should trigger ``AssertionError``."""
         inshp = (10, 8)
         name = '2foobar'
         a = keras.layers.Input(shape=inshp)
@@ -36,6 +38,7 @@ class TestChecks(unittest.TestCase):
             keras2c_main.k2c(model, name)
 
     def test_supported_layers(self):
+        """Unsupported layers should fail the conversion checks."""
         inshp = (10, 8)
         name = 'foobar'
         a = keras.layers.Input(shape=inshp)
@@ -45,11 +48,13 @@ class TestChecks(unittest.TestCase):
             keras2c_main.k2c(model, name)
 
     def test_activation_supported(self):
+        """Unsupported activations should raise ``AssertionError``."""
         inshp = (10, 8)
         name = 'foobar_1'
         a = keras.layers.Input(shape=inshp)
-        b = keras.layers.LSTM(10, activation='gelu',
-                              recurrent_activation='swish')(a)
+        b = keras.layers.LSTM(
+            10, activation='gelu', recurrent_activation='swish'
+        )(a)
         model = keras.models.Model(inputs=a, outputs=b)
         with self.assertRaises(AssertionError):
             keras2c_main.k2c(model, name)
@@ -69,6 +74,7 @@ class TestConfigSupported(unittest.TestCase):
             keras2c_main.k2c(model, name)
 
     def test_shared_axes(self):
+        """PReLU with shared axes is currently unsupported."""
         inshp = (10, 8, 12)
         name = 'foobar'
         a = keras.layers.Input(shape=inshp)
@@ -78,16 +84,19 @@ class TestConfigSupported(unittest.TestCase):
             keras2c_main.k2c(model, name)
 
     def test_data_format(self):
+        """Unsupported data format should trigger ``AssertionError``."""
         inshp = (8, 12)
         name = 'foobar'
         a = keras.layers.Input(shape=inshp)
-        b = keras.layers.Conv1D(filters=10, kernel_size=2,
-                                data_format='channels_first')(a)
+        b = keras.layers.Conv1D(
+            filters=10, kernel_size=2, data_format='channels_first'
+        )(a)
         model = keras.models.Model(inputs=a, outputs=b)
         with self.assertRaises(AssertionError):
             keras2c_main.k2c(model, name)
 
     def test_broadcast_merge(self):
+        """Merging tensors of different sizes should fail."""
         inshp1 = (12,)
         inshp2 = (10, 12)
         name = 'foobar'


### PR DESCRIPTION
## Summary
- add pre-commit config for pylint
- configure pylint options via `.pylintrc`
- install project requirements in pylint workflow
- document test helpers
- clean up whitespace in weights file
- add docstring for CLI entry point

## Testing
- `pytest -q` *(fails: AssertionError in tests)*
- `python3 -m pylint $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68410ee27ae48324a66009f12e55cbe0