### PR TITLE
Update module license headers

### DIFF
--- a/src/keras2c/__init__.py
+++ b/src/keras2c/__init__.py
@@ -1,7 +1,7 @@
 """__init__.py
 This file is part of keras2c
 Copyright 2020 Rory Conlin
-Licensed under MIT License
+Licensed under LGPLv3
 https://github.com/f0uriest/keras2c
 """
 

--- a/src/keras2c/__main__.py
+++ b/src/keras2c/__main__.py
@@ -1,7 +1,7 @@
 """__main__.py
 This file is part of keras2c
 Copyright 2020 Rory Conlin
-Licensed under MIT License
+Licensed under LGPLv3
 https://github.com/f0uriest/keras2c
 
 Runs keras2c

--- a/src/keras2c/check_model.py
+++ b/src/keras2c/check_model.py
@@ -1,7 +1,7 @@
 """check_model.py
 This file is part of keras2c
 Copyright 2020 Rory Conlin
-Licensed under MIT License
+Licensed under LGPLv3
 https://github.com/f0uriest/keras2c
 
 Checks a model before conversion to flag unsupported features

--- a/src/keras2c/io_parsing.py
+++ b/src/keras2c/io_parsing.py
@@ -1,7 +1,7 @@
 """io_parsing.py
 This file is part of keras2c
 Copyright 2020 Rory Conlin
-Licensed under MIT License
+Licensed under LGPLv3
 https://github.com/f0uriest/keras2c
 
 Helper functions to get input and output names for each layer etc.

--- a/src/keras2c/keras2c_main.py
+++ b/src/keras2c/keras2c_main.py
@@ -1,7 +1,7 @@
 """keras2c_main.py
 This file is part of keras2c
 Copyright 2020 Rory Conlin
-Licensed under MIT License
+Licensed under LGPLv3
 https://github.com/f0uriest/keras2c
 
 Converts keras model to C code

--- a/src/keras2c/layer2c.py
+++ b/src/keras2c/layer2c.py
@@ -1,7 +1,7 @@
 """layer2c.py
 This file is part of keras2c
 Copyright 2020 Rory Conlin
-Licensed under MIT License
+Licensed under LGPLv3
 https://github.com/f0uriest/keras2c
 
 Writes individual layers to C code

--- a/src/keras2c/make_test_suite.py
+++ b/src/keras2c/make_test_suite.py
@@ -1,7 +1,7 @@
 """make_test_suite.py
 This file is part of keras2c
 Copyright 2020 Rory Conlin
-Licensed under MIT License
+Licensed under LGPLv3
 https://github.com/f0uriest/keras2c
 
 Generates automatic test suite for converted code

--- a/src/keras2c/weights2c.py
+++ b/src/keras2c/weights2c.py
@@ -1,7 +1,7 @@
 """weights2c.py
 This file is part of keras2c
 Copyright 2020 Rory Conlin
-Licensed under MIT License
+Licensed under LGPLv3
 https://github.com/f0uriest/keras2c
 
 Gets weights and other parameters from each layer and writes to C file


### PR DESCRIPTION
## Summary
- update license headers in `src/keras2c` modules to reference LGPLv3

## Testing
- `pytest -q` *(fails: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_6841128b71648324874880219d41da94