### PR TITLE
Fix flake8 F541

### DIFF
--- a/src/keras2c/check_model.py
+++ b/src/keras2c/check_model.py
@@ -158,7 +158,7 @@ def config_supported_check(model):
         config = layer.get_config()
         if config.get('merge_mode', 'foo') is None:
             valid = False
-            log += f"Merge mode of 'None' for Bidirectional layers is not supported. Try using two separate RNNs instead.\n"
+            log += "Merge mode of 'None' for Bidirectional layers is not supported. Try using two separate RNNs instead.\n"
         if config.get('data_format') not in ['channels_last', None]:
             valid = False
             log += f"Data format '{config.get('data_format')}' for layer '{layer.name}' is not supported at this time.\n"


### PR DESCRIPTION
## Summary
- remove unused f-string in `check_model`

## Testing
- `flake8 src/keras2c/check_model.py`
- `pytest -q` *(fails: heavy tensorflow tests)*

------
https://chatgpt.com/codex/tasks/task_e_6841128c17808324ac3db432efc0a3df