### PR TITLE
Replace flake8 with ruff

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.10
   - pytest
-  - flake8
+  - ruff
   - numpy
   - pandas
   - tensorflow>=2.0


### PR DESCRIPTION
## Summary
- switch lint dependency in `environment.yml` from flake8 to ruff

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_68411680785083248462ddadf5298899