### PR TITLE
Update linter config to use ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 repos:
-  - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v2.15.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.12
     hooks:
-      - id: pylint
-        additional_dependencies: [tensorflow, numpy]
+      - id: ruff


### PR DESCRIPTION
## Summary
- switch pre-commit linter from pylint mirror to ruff-pre-commit
- use tag v0.11.12

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*
- `pre-commit run --files .pre-commit-config.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841167d27f083248e3401509b780c86