### PR TITLE
Fix dtype handling & LeakyReLU test

### DIFF
--- a/src/keras2c/weights2c.py
+++ b/src/keras2c/weights2c.py
@@ -674,7 +674,8 @@ class Weights2C:
         self.stack_vars += '\n\n'
 
     def _write_weights_LeakyReLU(self, layer):
-        alpha = layer.get_config()['negative_slope']
+        cfg = layer.get_config()
+        alpha = cfg.get('negative_slope', cfg.get('alpha'))
         self.stack_vars += 'float ' + layer.name + \
             '_negative_slope = ' + str(alpha) + '; \n'
         self.stack_vars += '\n\n'

--- a/tests/test_advanced_activation_layers.py
+++ b/tests/test_advanced_activation_layers.py
@@ -26,7 +26,7 @@ class TestAdvancedActivation(unittest.TestCase):
         inshp = (9, 7, 6, 3)
         alpha = 0.5
         a = keras.Input(shape=inshp)
-        b = keras.layers.LeakyReLU(negative_slope=alpha)(a)
+        b = keras.layers.LeakyReLU(alpha=alpha)(a)
         model = keras.Model(inputs=a, outputs=b)
         name = 'test___LeakyReLU' + str(int(time.time()))
         keras2c_main.k2c(model, name)


### PR DESCRIPTION
## Summary
- handle TensorFlow dtypes when generating random inputs
- accept `alpha` or `negative_slope` in LeakyReLU weights
- update LeakyReLU test for current Keras

## Testing
- `pytest tests/test_recurrent_layers.py::TestRecurrentLayers::test_LSTM3 -q`
- `pytest tests/test_advanced_activation_layers.py::TestAdvancedActivation::test_LeakyReLU -q`


------
https://chatgpt.com/codex/tasks/task_e_6841153c49d4832488cc06fb62457e4e