### PR TITLE
Fix Ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,4 +61,4 @@ testpaths = ["tests"]
 [tool.ruff]
 line-length = 120
 target-version = "py310"
-ignore = ["F401", "F841"]
+extend-exclude = ["scratch"]


### PR DESCRIPTION
## Summary
- clean up conflict markers in `pyproject.toml`
- set `line-length`, `target-version`, and `extend-exclude` for Ruff

## Testing
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68411cdd6588832495fa46ba3a1a6a13