### PR TITLE
Fix ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,4 +61,5 @@ testpaths = ["tests"]
 [tool.ruff]
 line-length = 120
 target-version = "py310"
+extend-exclude = ["scratch"]
 ignore = ["F401", "F841"]


### PR DESCRIPTION
## Summary
- ensure pyproject.toml has no merge conflict markers
- configure ruff line length, python version and exclude scratch folder

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68411ce48b1c8324be3a95ca09de06a0