### PR TITLE
Remove unused variables and imports in tests

### DIFF
--- a/tests/test_malloc.py
+++ b/tests/test_malloc.py
@@ -10,7 +10,6 @@ from tensorflow import keras
 from keras2c import keras2c_main
 import time
 from test_core_layers import build_and_run
-import tensorflow as tf
 
 
 __author__ = "Rory Conlin"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,12 +6,19 @@ Implements tests for full models
 #!/usr/bin/env python3
 
 import unittest
-from tensorflow import keras
-from tensorflow.keras import layers
 from tensorflow.keras.layers import (
-    Input, Dense, LSTM, Conv1D, Conv2D, ConvLSTM2D, Dot, Add,
-    Multiply, Concatenate, Reshape, Permute, ZeroPadding1D, Cropping1D,
-    Activation, MaxPooling2D, Dropout, Flatten
+    Input,
+    Dense,
+    LSTM,
+    Conv1D,
+    Conv2D,
+    Add,
+    Concatenate,
+    Reshape,
+    Permute,
+    MaxPooling2D,
+    Dropout,
+    Flatten,
 )
 from tensorflow.keras.models import Model, Sequential
 from keras2c import keras2c_main
@@ -177,7 +184,6 @@ class TestModels(unittest.TestCase):
         input_profile_names = ['a', 'b', 'c']
         target_profile_names = ['a', 'b']
         actuator_names = ['aa', 'bb', 'cc']
-        lookbacks = {'a': 1, 'b': 1, 'c': 1, 'aa': 5, 'bb': 5, 'cc': 5}
         profile_lookback = 1
         actuator_lookback = 5
         lookahead = 4

--- a/tests/test_pooling_layers.py
+++ b/tests/test_pooling_layers.py
@@ -6,8 +6,6 @@ Implements tests for pooling layers
 #!/usr/bin/env python3
 
 import unittest
-from tensorflow import keras
-from tensorflow.keras import layers
 from tensorflow.keras.layers import (
     Input, MaxPooling1D, AveragePooling1D, MaxPooling2D, AveragePooling2D,
     GlobalAveragePooling1D, GlobalMaxPooling1D, GlobalAveragePooling2D,

--- a/tests/test_recurrent_layers.py
+++ b/tests/test_recurrent_layers.py
@@ -6,7 +6,6 @@ Implements tests for recurrent layers
 #!/usr/bin/env python3
 
 import unittest
-from tensorflow import keras
 from tensorflow.keras.layers import Input, SimpleRNN, LSTM, GRU
 from tensorflow.keras.models import Model
 from keras2c import keras2c_main


### PR DESCRIPTION
## Summary
- clean up unused imports in multiple test files
- remove unused lookbacks var in `test_models`

## Testing
- `ruff check tests`
- `ruff check tests --select F401,F841 --isolated -n`

------
https://chatgpt.com/codex/tasks/task_e_68411cee204c832490412a2cd4121095