### PR TITLE
Fix long lines for ruff

### DIFF
--- a/src/keras2c/__main__.py
+++ b/src/keras2c/__main__.py
@@ -34,7 +34,10 @@ def parse_args(args):
         "-m",
         "--malloc",
         action="store_true",
-        help="""Use dynamic memory for large arrays. Weights will be saved to .csv files that will be loaded at runtime"""
+        help=(
+            "Use dynamic memory for large arrays. "
+            "Weights will be saved to .csv files that will be loaded at runtime"
+        ),
     )
     parser.add_argument(
         "-t",

--- a/src/keras2c/check_model.py
+++ b/src/keras2c/check_model.py
@@ -121,10 +121,16 @@ def activation_supported_check(model):
         recurrent_activation = config.get('recurrent_activation')
         if activation not in supported_activations and activation is not None:
             valid = False
-            log += f"Activation type '{activation}' for layer '{layer.name}' is not supported at this time.\n"
+            log += (
+                f"Activation type '{activation}' for layer '{layer.name}' "
+                "is not supported at this time.\n"
+            )
         if recurrent_activation not in supported_activations and recurrent_activation is not None:
             valid = False
-            log += f"Recurrent activation type '{recurrent_activation}' for layer '{layer.name}' is not supported at this time.\n"
+            log += (
+                f"Recurrent activation type '{recurrent_activation}' for "
+                f"layer '{layer.name}' is not supported at this time.\n"
+            )
         return valid, log
 
     valid = True
@@ -158,16 +164,28 @@ def config_supported_check(model):
         config = layer.get_config()
         if config.get('merge_mode', 'foo') is None:
             valid = False
-            log += "Merge mode of 'None' for Bidirectional layers is not supported. Try using two separate RNNs instead.\n"
+            log += (
+                "Merge mode of 'None' for Bidirectional layers is not "
+                "supported. Try using two separate RNNs instead.\n"
+            )
         if config.get('data_format') not in ['channels_last', None]:
             valid = False
-            log += f"Data format '{config.get('data_format')}' for layer '{layer.name}' is not supported at this time.\n"
+            log += (
+                f"Data format '{config.get('data_format')}' for layer "
+                f"'{layer.name}' is not supported at this time.\n"
+            )
         if config.get('return_state'):
             valid = False
-            log += f"'return_state' option for layer '{layer.name}' is not supported at this time.\n"
+            log += (
+                f"'return_state' option for layer '{layer.name}' is "
+                "not supported at this time.\n"
+            )
         if config.get('shared_axes'):
             valid = False
-            log += f"'shared_axes' option for layer '{layer.name}' is not supported at this time.\n"
+            log += (
+                f"'shared_axes' option for layer '{layer.name}' is "
+                "not supported at this time.\n"
+            )
         if layer_type(layer) in ['Add', 'Subtract', 'Multiply', 'Average',
                                  'Maximum', 'Minimum']:
             inshps = [tensor.shape for tensor in layer.input]
@@ -179,7 +197,11 @@ def config_supported_check(model):
                     insize.append(np.prod(shape))
                 if len(set(insize)) > 1:
                     valid = False
-                    log += f"Broadcasting merge functions between tensors of different shapes for layer '{layer.name}' is not currently supported.\n"
+                    log += (
+                        "Broadcasting merge functions between tensors of "
+                        f"different shapes for layer '{layer.name}' is not "
+                        "currently supported.\n"
+                    )
         if layer_type(layer) in ['BatchNormalization']:
             if isinstance(config.get('axis'), (list, tuple)) and len(flatten(config.get('axis'))) > 1:
                 valid = False

--- a/src/keras2c/make_test_suite.py
+++ b/src/keras2c/make_test_suite.py
@@ -187,13 +187,18 @@ def make_test_suite(
     file.write("\n")
     s = "clock_t t1 = clock(); \n"
     s += (
-        f'printf("Average time over {num_tests} tests: %e s \\n", \n ((double)t1-t0)/(double)CLOCKS_PER_SEC/(double){num_tests}); \n'
+        f'printf("Average time over {num_tests} tests: %e s \\n",\n'
+        f'        ((double)t1-t0)/(double)CLOCKS_PER_SEC/(double){num_tests}); \n'
     )
     file.write(s)
 
     for i in range(num_tests):
         for j in range(num_outputs):
-            s = f"errors[{i * num_outputs + j}] = maxabs(&keras_{model_outputs[j]}_test{i + 1},&c_{model_outputs[j]}_test{i + 1}); \n"
+            s = (
+                f"errors[{i * num_outputs + j}] = "
+                f"maxabs(&keras_{model_outputs[j]}_test{i + 1},"
+                f"&c_{model_outputs[j]}_test{i + 1}); \n"
+            )
             file.write(s)
     s = "float maxerror = errors[0]; \n"
     s += "for(size_t i=1; i< num_tests*num_outputs;i++){ \n"

--- a/src/keras2c/weights2c.py
+++ b/src/keras2c/weights2c.py
@@ -60,7 +60,10 @@ class Weights2C:
         shp = np.concatenate((shp, np.ones(maxndim - ndim)))
         if malloc:
             to_malloc = {}
-            s = f'k2c_tensor {name} = {{ {name}_array, {ndim}, {size}, {{ {np.array2string(shp.astype(int), separator=",")[1:-1]} }} }}; \n'
+            s = (
+                f'k2c_tensor {name} = {{ {name}_array, {ndim}, {size}, '
+                f'{{ {np.array2string(shp.astype(int), separator=",")[1:-1]} }} }}; \n'
+            )
             to_malloc.update({f'{name}_array': temp})
             return s, to_malloc
         else:
@@ -81,7 +84,10 @@ class Weights2C:
                     if count % 5 == 0:
                         s += '\n'
                 s += '}; \n'
-            s += f'k2c_tensor {name} = {{ &{name}_array[0], {ndim}, {size}, {{ {np.array2string(shp.astype(int), separator=",")[1:-1]} }} }}; \n'
+            s += (
+                f'k2c_tensor {name} = {{ &{name}_array[0], {ndim}, {size}, '
+                f'{{ {np.array2string(shp.astype(int), separator=",")[1:-1]} }} }}; \n'
+            )
             return s
 
     def _write_weights_array2c(self, array, name):

--- a/tests/test_core_layers.py
+++ b/tests/test_core_layers.py
@@ -58,11 +58,13 @@ class TestCoreLayers(unittest.TestCase):
     Unit tests for core Keras layers using keras2c.
     This test suite includes the following tests:
     - test_Dense1: Tests a Dense layer with ReLU activation.
-    - test_Dense2_Activation: Tests a Dense layer without bias followed by an Activation layer with exponential activation.
+    - test_Dense2_Activation: Tests a Dense layer without bias followed by an
+      Activation layer with exponential activation.
     - test_Dropout_Reshape_Flatten: Tests a sequence of Flatten, Dropout, and Reshape layers.
     - test_Permute: Tests a Permute layer.
     - test_repeat_vector: Tests a RepeatVector layer followed by an ActivityRegularization and Dense layer.
-    - test_dummy_layers: Tests a sequence of SpatialDropout3D, Reshape, SpatialDropout2D, Reshape, SpatialDropout1D, and Flatten layers.
+    - test_dummy_layers: Tests a sequence of SpatialDropout3D, Reshape,
+      SpatialDropout2D, Reshape, SpatialDropout1D, and Flatten layers.
     Each test builds a Keras model, converts it using keras2c, and verifies that the generated code runs successfully.
     """
 


### PR DESCRIPTION
## Summary
- break long CLI help text
- shorten log text in `check_model` helpers
- reformat lines in `make_test_suite`
- wrap f-strings in `weights2c`
- shorten a long docstring in `tests/test_core_layers`

## Testing
- `ruff check .` *(fails: SyntaxError in scratch notebook but no E501)*

------
https://chatgpt.com/codex/tasks/task_e_68411d477768832483af0fc535974e46