### PR TITLE
Fix unused vars and improve exception handling

### DIFF
--- a/src/keras2c/keras2c_main.py
+++ b/src/keras2c/keras2c_main.py
@@ -222,7 +222,6 @@ def k2c(model, function_name, malloc=False, num_tests=10, verbose=True):
     verbose = cfg.verbose
 
     function_name = str(function_name)
-    filename = function_name + '.c'
     if isinstance(model, str):
         model = keras.load_model(model)
     elif not isinstance(model, keras.Model):

--- a/src/keras2c/layer2c.py
+++ b/src/keras2c/layer2c.py
@@ -555,8 +555,6 @@ class Layers2C():
         nm = ctx.name
         inputs = ctx.inputs
         outputs = ctx.outputs
-        is_model_input = ctx.is_model_input
-        is_model_output = ctx.is_model_output
         self.layers += 'k2c_reshape(' + outputs + ',' + inputs + ',' + nm + \
             '_newshp,' + nm + '_newndim); \n'
 

--- a/src/keras2c/types.py
+++ b/src/keras2c/types.py
@@ -24,3 +24,6 @@ class Keras2CConfig(BaseModel):
     malloc: bool = False
     num_tests: int = 10
     verbose: bool = True
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/src/keras2c/weights2c.py
+++ b/src/keras2c/weights2c.py
@@ -175,13 +175,13 @@ class Weights2C:
                                         backward_output_shape_no_batch)) + '}; \n'
         """
         try:
-            foo = layer.forward_layer.input_shape
-            foo = layer.backward_layer.input_shape
-        except:
+            layer.forward_layer.input_shape
+            layer.backward_layer.input_shape
+        except Exception:
             temp_input = keras.layers.Input(shape=layer.input_shape[2:])
-            foo = layer.layer(temp_input)
-            foo = layer.forward_layer(temp_input)
-            foo = layer.backward_layer(temp_input)
+            layer.layer(temp_input)
+            layer.forward_layer(temp_input)
+            layer.backward_layer(temp_input)
         self._write_weights_layer(layer.backward_layer)
         self._write_weights_layer(layer.forward_layer)
         if layer.merge_mode:
@@ -203,10 +203,10 @@ class Weights2C:
     def _write_weights_TimeDistributed(self, layer):
         self._write_outputs(layer)
         try:
-            foo = layer.layer.input_shape
+            layer.layer.input_shape
         except Exception:
             temp_input = keras.layers.Input(shape=layer.input.shape[2:], batch_size=1)
-            foo = layer.layer(temp_input)
+            layer.layer(temp_input)
         self._write_weights_layer(layer.layer)
         timeslice_input = np.squeeze(np.zeros(layer.layer.input.shape[1:]))
         timeslice_output = np.squeeze(np.zeros(layer.layer.output.shape[1:]))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -177,7 +177,6 @@ class TestModels(unittest.TestCase):
         input_profile_names = ['a', 'b', 'c']
         target_profile_names = ['a', 'b']
         actuator_names = ['aa', 'bb', 'cc']
-        lookbacks = {'a': 1, 'b': 1, 'c': 1, 'aa': 5, 'bb': 5, 'cc': 5}
         profile_lookback = 1
         actuator_lookback = 5
         lookahead = 4


### PR DESCRIPTION
## Summary
- remove unused filename variable
- clean up unused `foo` and handle exception properly in weights2c
- drop unused variables in layer2c and tests
- allow arbitrary types in Keras2CConfig
- run ruff lint
- run tests (failures expected)

## Testing
- `ruff check . --select F841,E722`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411d340ce48324a07162cd36c78226