### PR TITLE
Fix runtime typing for Python 3.6

### DIFF
--- a/src/keras2c/types.py
+++ b/src/keras2c/types.py
@@ -1,8 +1,9 @@
-from __future__ import annotations
-
-from typing import List, Union
+from typing import List, Union, TYPE_CHECKING
 from pydantic import BaseModel
 from .backend import keras
+
+if TYPE_CHECKING:
+    from .backend import keras as _keras_typing  # noqa: F401
 
 
 class LayerIO(BaseModel):
@@ -19,7 +20,7 @@ class LayerIO(BaseModel):
 class Keras2CConfig(BaseModel):
     """Configuration for :func:`keras2c_main.k2c`."""
 
-    model: Union[keras.Model, str]
+    model: Union["keras.Model", str]
     function_name: str
     malloc: bool = False
     num_tests: int = 10
@@ -27,3 +28,6 @@ class Keras2CConfig(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
+
+
+Keras2CConfig.update_forward_refs(keras=keras)


### PR DESCRIPTION
## Summary
- drop `from __future__ import annotations`
- use runtime string annotations in `types.py`
- update pydantic forward refs

## Testing
- `ruff check src tests`
- `pytest -q` *(fails: compilation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68412216ed30832496f660971131cdaa