### PR TITLE
Update ruff workflow to Python 3.12

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python


### PR DESCRIPTION
## Summary
- update CI ruff lint job to Python 3.12

## Testing
- `pre-commit run --files .github/workflows/ruff.yml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_68412f020e788324bbb3e60b3fb074fb