### PR TITLE
Add Nox CI for multiple Python versions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,23 +14,24 @@ permissions:
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ruff pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with ruff
+        pip install nox
+    - name: Run Nox
       run: |
-        ruff check .
-    - name: Test with pytest
-      run: |
-        pytest
+        nox -s tests

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,18 @@
+import nox
+
+PYTHON_VERSIONS = [
+    "3.7",
+    "3.8",
+    "3.9",
+    "3.10",
+    "3.11",
+    "3.12",
+    "3.13",
+]
+
+@nox.session(python=PYTHON_VERSIONS)
+def tests(session):
+    session.install("-r", "requirements.txt")
+    session.install("pytest", "ruff")
+    session.run("ruff", "check", ".")
+    session.run("pytest")


### PR DESCRIPTION
## Summary
- add `noxfile.py`
- update CI workflow to use Nox and run tests on ubuntu and windows across Python 3.7 to 3.13

## Testing
- `ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684132a2292c8324aa99a42e25ff56f7