### PR TITLE
Add Windows/macOS CI support

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,12 +17,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4
+    - name: Set up build tools on Windows
+      if: runner.os == 'Windows'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        update: true
+        install: >-
+          mingw-w64-x86_64-gcc
+          make
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
       with:
@@ -32,9 +41,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install ruff pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      shell: bash
     - name: Lint with ruff
       run: |
         ruff check .
+      shell: bash
     - name: Test with pytest
       run: |
         pytest
+      shell: bash


### PR DESCRIPTION
## Summary
- expand GitHub Actions matrix to run on Ubuntu, macOS, and Windows
- install gcc/make on Windows via `msys2/setup-msys2`
- run shell commands with bash for cross-platform compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b6c7523c83249044285764438e09