### PR TITLE
Allow overriding compiler

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -26,5 +26,8 @@ Additional packages for building the documentation and running the tests are inc
     pip install -r tests/requirements.txt
 
 
-By default, the tests compile code with ``gcc``. This can be modified to use a different compiler by changing the variable ``CC`` in ``tests/test_core_layers.py`` and ``include/makefile``
-It is also recommended to install ``astyle`` to automatically format the generated code.
+By default, the tests compile code with ``gcc``. You can set the ``CC``
+environment variable to use a different compiler, for example ``clang`` on macOS
+or ``gcc`` from MSYS2/MinGW on Windows.  The makefile will fall back to ``gcc``
+if ``CC`` is unset.  It is also recommended to install ``astyle`` to
+automatically format the generated code.

--- a/include/makefile
+++ b/include/makefile
@@ -1,5 +1,5 @@
 
-CC=gcc
+CC ?= gcc
 
 ifeq ($(CC), gcc)
 	OPTFLAGS = -O3 -march=native 

--- a/tests/test_core_layers.py
+++ b/tests/test_core_layers.py
@@ -19,7 +19,7 @@ __maintainer__ = "Rory Conlin, https://github.com/f0uriest/keras2c"
 __email__ = "wconlin@princeton.edu"
 
 
-CC = 'gcc'
+CC = os.environ.get('CC', 'gcc')
 
 
 def build_and_run(name, return_output=False):


### PR DESCRIPTION
## Summary
- let `tests/test_core_layers.py` read CC from the environment
- allow overriding `CC` in `include/makefile`
- document compiler selection and common choices for macOS and Windows

## Testing
- `ruff check tests/test_core_layers.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b6c887cc8324a9fd2f0b29e1dfaa