### PR TITLE
Update OS quickstart tips and installation docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,12 @@ Please cite `this paper <https://doi.org/10.1016/j.engappai.2021.104182>`_ if yo
 Quickstart
 **********
 
-For windows, make sure that you have gcc installed. We recommend CYGWIN with make and gcc
+On macOS, ensure the Xcode command line tools are installed so that ``make``
+and ``clang`` are available.  You can install them from a terminal with
+``xcode-select --install``.
+
+For Windows, ``make`` and ``gcc`` are not included by default.  Use
+MSYS2/MinGW or Cygwin to obtain these tools.
 
 After cloning the repo, install the necessary packages with ``pip install -r requirements.txt``.
 Alternatively, create a conda environment using ``conda env create -f environment.yml``.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,6 +5,10 @@ Installation
 
 keras2c can be downloaded from github: https://github.com/f0uriest/keras2c
 
+On macOS, install the Xcode command line tools so ``make`` and ``clang`` are
+available (run ``xcode-select --install``).  Windows users should install
+``make`` and ``gcc`` through MSYS2/MinGW or Cygwin.
+
 The Python requirements can be installed with pip:
 
 .. code-block:: bash
@@ -26,5 +30,6 @@ Additional packages for building the documentation and running the tests are inc
     pip install -r tests/requirements.txt
 
 
-By default, the tests compile code with ``gcc``. This can be modified to use a different compiler by changing the variable ``CC`` in ``tests/test_core_layers.py`` and ``include/makefile``
-It is also recommended to install ``astyle`` to automatically format the generated code.
+By default, the tests compile code with ``gcc``.  Set the environment variable
+``CC`` to override the compiler when running ``pytest`` or ``make``.  It is also
+recommended to install ``astyle`` to automatically format the generated code.


### PR DESCRIPTION
## Summary
- mention macOS and Windows requirements in the README Quickstart
- describe the CC environment variable override in installation docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b6c947a483249504b131b4c334b1