### PR TITLE
Fix library linking and CI build step

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -46,6 +46,9 @@ jobs:
       run: |
         ruff check .
       shell: bash
+    - name: Build C library
+      run: make -C include
+      shell: bash
     - name: Test with pytest
       run: |
         pytest

--- a/docs/_sources/usage.rst.txt
+++ b/docs/_sources/usage.rst.txt
@@ -70,7 +70,7 @@ The test suite (or other main program) can then be compiled with:
 
 .. code-block:: bash
 		
-    gcc -std=c99 -I./include/ -o <executable_name> <function_name>.c <function_name>_test_suite.c -L./include/ -l:libkeras2c.a -lm
+    gcc -std=c99 -I./include/ -o <executable_name> <function_name>.c <function_name>_test_suite.c -L./include/ -lkeras2c -lm
 
     
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -70,7 +70,7 @@ The test suite (or other main program) can then be compiled with:
 
 .. code-block:: bash
 		
-    gcc -std=c99 -I./include/ -o <executable_name> <function_name>.c <function_name>_test_suite.c -L./include/ -l:libkeras2c.a -lm
+    gcc -std=c99 -I./include/ -o <executable_name> <function_name>.c <function_name>_test_suite.c -L./include/ -lkeras2c -lm
 
     
 

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -206,7 +206,7 @@ For very large models or on machines with limited stack size this may lead to er
 <code class="docutils literal notranslate"><span class="pre">&lt;function_name&gt;_test_suite.c</span></code> contains a <code class="docutils literal notranslate"><span class="pre">main</span></code> program to run sample inputs through the generated code to ensure that it produces the same outputs as the original python model.</p>
 <p>To compile and run the tests, the C backend must be built first. This can be done by running <code class="docutils literal notranslate"><span class="pre">make</span></code> from within the <code class="docutils literal notranslate"><span class="pre">include</span></code> folder, to generate <code class="docutils literal notranslate"><span class="pre">libkeras2c.a</span></code>.
 The test suite (or other main program) can then be compiled with:</p>
-<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>gcc -std<span class="o">=</span>c99 -I./include/ -o &lt;executable_name&gt; &lt;function_name&gt;.c &lt;function_name&gt;_test_suite.c -L./include/ -l:libkeras2c.a -lm
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>gcc -std<span class="o">=</span>c99 -I./include/ -o &lt;executable_name&gt; &lt;function_name&gt;.c &lt;function_name&gt;_test_suite.c -L./include/ -lkeras2c -lm
 </pre></div>
 </div>
 </div>

--- a/tests/test_core_layers.py
+++ b/tests/test_core_layers.py
@@ -44,8 +44,18 @@ def build_and_run(name, return_output=False):
     else:
         ccflags = '-Ofast -std=c99 -I./include/'
 
-    cc = CC + ' ' + ccflags + ' -o ' + name + ' ' + name + '.c ' + \
-        name + '_test_suite.c -L./include/ -l:libkeras2c.a -lm'
+    cc = (
+        CC
+        + ' '
+        + ccflags
+        + ' -o '
+        + name
+        + ' '
+        + name
+        + '.c '
+        + name
+        + '_test_suite.c -L./include/ -lkeras2c -lm'
+    )
     build_process = subprocess.run(
         cc,
         shell=True,


### PR DESCRIPTION
## Summary
- link test executables using `-lkeras2c`
- build `libkeras2c.a` before running tests in CI
- update usage docs to use portable linker flag

## Testing
- `ruff check tests/test_core_layers.py`
- `pytest -k Activation1 -vv tests/test_core_layers.py` *(fails: `ModuleNotFoundError: No module named 'tensorflow'`)*

------
https://chatgpt.com/codex/tasks/task_e_6854f378dca0832496496ae142872d28