### PR TITLE
Fix GCC build in workflow and tests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -46,7 +46,12 @@ jobs:
       run: |
         ruff check .
       shell: bash
+    - name: Build C library
+      run: make CC=gcc -C include
+      shell: bash
     - name: Test with pytest
+      env:
+        CC: gcc
       run: |
         pytest
       shell: bash

--- a/tests/test_core_layers.py
+++ b/tests/test_core_layers.py
@@ -26,7 +26,7 @@ def build_and_run(name, return_output=False):
     cwd = os.getcwd()
     os.chdir(os.path.abspath('./include/'))
     lib_process = subprocess.run(
-        ['make'],
+        'make CC=' + CC,
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,


### PR DESCRIPTION
## Summary
- ensure workflow builds C lib with GCC
- force GCC in pytest step
- allow tests to build library with selected compiler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685581c024888324990b3be8306f3159